### PR TITLE
feat: write logs to debug phone-island messages

### DIFF
--- a/src/main/classes/windows/PhoneIslandWindow.ts
+++ b/src/main/classes/windows/PhoneIslandWindow.ts
@@ -1,5 +1,6 @@
 import { PAGES } from '@shared/types'
 import { BaseWindow } from './BaseWindow'
+import { ipcMain } from 'electron'
 
 export class PhoneIslandWindow extends BaseWindow {
 
@@ -30,16 +31,48 @@ export class PhoneIslandWindow extends BaseWindow {
       thickFrame: false,
       trafficLightPosition: { x: 0, y: 0 },
       webPreferences: {
-        nodeIntegration: true
+        nodeIntegration: true,
+        backgroundThrottling: false
       }
     })
 
-    // Set window level to ensure it appears above fullscreen applications
-    // This works across all platforms (macOS, Windows, Linux)
     this.addOnBuildListener(() => {
       const window = this.getWindow()
       if (window) {
+        // Set window level to ensure it appears above fullscreen applications
         window.setAlwaysOnTop(true, 'screen-saver')
+
+        // Override console methods in the renderer to serialize objects before logging.
+        // Without this, Chromium's console-message event converts objects to "[object Object]".
+        window.webContents.on('did-finish-load', () => {
+          window.webContents.executeJavaScript(`
+            (function() {
+              const serialize = (arg) => {
+                if (arg === null || arg === undefined) return String(arg);
+                if (typeof arg === 'object') {
+                  try { return JSON.stringify(arg); } catch(e) { return String(arg); }
+                }
+                return String(arg);
+              };
+              ['log', 'info', 'warn', 'error', 'debug'].forEach((method) => {
+                const original = console[method].bind(console);
+                console[method] = (...args) => {
+                  original(...args.map(serialize));
+                };
+              });
+            })();
+          `)
+        })
+
+        // Forward all console messages from PhoneIsland renderer to main process log file
+        // Uses 'phone-island-log' channel which always writes to file (not gated by isDev)
+        window.webContents.on('console-message', (_event, level, message, line, sourceId) => {
+          const levelMap = ['DEBUG', 'INFO', 'WARNING', 'ERROR']
+          const levelStr = levelMap[level] || 'INFO'
+          const source = sourceId ? sourceId.split('/').pop() : 'unknown'
+          const timestamp = new Date().toISOString().replace('T', ' ').replace('Z', '')
+          ipcMain.emit('phone-island-log', {}, `${timestamp} [PhoneIsland] [${levelStr}] ${message} (${source}:${line})`)
+        })
       }
     })
   }

--- a/src/main/lib/windowConstructor.ts
+++ b/src/main/lib/windowConstructor.ts
@@ -31,7 +31,8 @@ export function createWindow(
       preload: join(__dirname, '../preload/index.js'),
       sandbox: false,
       contextIsolation: false,
-      nodeIntegration: true
+      nodeIntegration: true,
+      ...config.webPreferences,
     },
     hiddenInMissionControl: false,
   })

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -201,6 +201,11 @@ function startLogger() {
     if (message && isDev())
       logOnFile(message)
   })
+  // Always log PhoneIsland renderer messages (for audio diagnostics in production)
+  ipcMain.on('phone-island-log', (_e, message) => {
+    if (message)
+      logOnFile(message)
+  })
 
   function deleteLogFile() {
     if (fs.existsSync(logFilePath)) {


### PR DESCRIPTION
## Summary

Forward all console messages from the PhoneIsland renderer window to the main process log file, so that audio/SIP diagnostics are captured in production without requiring DevTools access.

## Changes

- `src/main/classes/windows/PhoneIslandWindow.ts`:
  - Set `backgroundThrottling: false` to prevent Chromium from throttling timers/AudioContext when the window is hidden (critical for audio reliability during long holds).
  - Override `console.log/info/warn/error/debug` in the renderer to JSON-serialize object arguments, otherwise Chromium's `console-message` event emits `[object Object]`.
  - Listen to `console-message` and forward each message to the main process via a dedicated `phone-island-log` IPC channel.

- `src/main/lib/windowConstructor.ts`:
  - Spread `config.webPreferences` inside the shared `webPreferences` block so that per-window options (like `backgroundThrottling`) are not silently dropped by the default values.

- `src/main/main.ts`:
  - Register an `ipcMain.on('phone-island-log', ...)` handler that always writes to the log file, independent of `isDev()`, so production installs also record the diagnostics.