### PR TITLE
fix: align AppUserModelId with electron-builder appId

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -53,8 +53,7 @@ Log.debug('ENV:', process.env)
 
 function startup() {
   app.setName('NethLink')
-  //if (isDev())
-  app.setAppUserModelId(app.getName()) //add app name to the notification title
+  app.setAppUserModelId('com.nethesis.nethlink.app') //must match electron-builder appId so Windows notification permissions and taskbar pinning work correctly
   ///LOGGER
   startLogger()
 


### PR DESCRIPTION
## Summary

On Windows, toast notifications were always delivered even when the user had disabled notifications for the app in **Settings > System > Notifications**, while on macOS the OS-level toggle was correctly respected.

### Root cause

Windows tracks per-app notification permissions by **AppUserModelId (AUMID)**. The permission toggle that the user sees in system settings is associated with the AUMID registered by the Start Menu shortcut. In this project there was a mismatch:

- NSIS installer registers the shortcut with AUMID `com.nethesis.nethlink.app` (from `appId` in `electron-builder.yml`).
- The runtime process declared AUMID `NethLink` (via `app.setAppUserModelId(app.getName())` in `src/main/main.ts`).

Because the emitted toasts were tagged with an AUMID that did not match the one the user toggled off, Windows had no permission entry to match and delivered the notifications anyway. The same mismatch is also responsible for taskbar pinning glitches (pinned icon not activating when the app is running, second ghost icon appearing on launch).

### Fix

Set the runtime AUMID explicitly to `com.nethesis.nethlink.app`, matching the installer `appId`. Notifications are now correctly suppressed by Windows when the user disables them, and the taskbar pinned icon properly tracks the running instance.

### Scope / regressions

- `app.setName('NethLink')` is unchanged, so `app.getName()` still returns `"NethLink"` and all consumers (`tel:`/`callto:`/`nethlink:` protocol registration in the Windows registry, window titles, tray, menus, locales) keep working as before.
- No jump lists or user tasks are registered in the codebase, so no data is orphaned.
- In production the toast header still reads "NethLink" because Windows resolves the AUMID to the Start Menu shortcut name.
- Users who already had NethLink pinned to the taskbar on a prior version may need to unpin and re-pin once after updating, since the old pinned entry is bound to the previous transient AUMID.