### PR TITLE
fix(win): sign inner app binary, not just the installer

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -65,12 +65,11 @@ jobs:
       - name: Install Linux build dependencies (libuiohook/X11)
         if: matrix.os == 'ubuntu-latest'
         # uiohook-napi is rebuilt from source against Electron's ABI and needs
-        # the X11 dev headers (X11/keysym.h) to compile libuiohook.
+        # the X11 dev headers to compile libuiohook. Packages match the
+        # libraries linked in uiohook-napi's binding.gyp: -lX11 -lXrandr -lXtst -lXt
         run: |
           sudo apt-get update
-          sudo apt-get install -y libx11-dev libxtst-dev libxt-dev \
-            libxinerama-dev libx11-xcb-dev libxkbcommon-dev \
-            libxkbcommon-x11-dev libxkbfile-dev
+          sudo apt-get install -y libx11-dev libxrandr-dev libxtst-dev libxt-dev
 
       - name: Build/release Electron app
         uses: samuelmeuli/action-electron-builder@v1

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -62,6 +62,16 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
 
+      - name: Install Linux build dependencies (libuiohook/X11)
+        if: matrix.os == 'ubuntu-latest'
+        # uiohook-napi is rebuilt from source against Electron's ABI and needs
+        # the X11 dev headers (X11/keysym.h) to compile libuiohook.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libx11-dev libxtst-dev libxt-dev \
+            libxinerama-dev libx11-xcb-dev libxkbcommon-dev \
+            libxkbcommon-x11-dev libxkbfile-dev
+
       - name: Build/release Electron app
         uses: samuelmeuli/action-electron-builder@v1
         with:

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -41,12 +41,11 @@ jobs:
       - name: Install Linux build dependencies (libuiohook/X11)
         if: matrix.os == 'ubuntu-latest'
         # uiohook-napi is rebuilt from source against Electron's ABI and needs
-        # the X11 dev headers (X11/keysym.h) to compile libuiohook.
+        # the X11 dev headers to compile libuiohook. Packages match the
+        # libraries linked in uiohook-napi's binding.gyp: -lX11 -lXrandr -lXtst -lXt
         run: |
           sudo apt-get update
-          sudo apt-get install -y libx11-dev libxtst-dev libxt-dev \
-            libxinerama-dev libx11-xcb-dev libxkbcommon-dev \
-            libxkbcommon-x11-dev libxkbfile-dev
+          sudo apt-get install -y libx11-dev libxrandr-dev libxtst-dev libxt-dev
 
       - name: Build/release Electron app (macOS/Linux)
         if: "!startsWith(matrix.os, 'windows')"
@@ -82,18 +81,20 @@ jobs:
           path: notarization-error.log
           if-no-files-found: ignore
 
-      # --- Windows: build (electron-builder signs every binary via Azure
-      # Trusted Signing during packaging), then upload ---
+      # --- Windows: build with the release config (electron-builder signs every
+      # binary via Azure Trusted Signing during packaging), then upload ---
       - name: Build Electron app (Windows)
         if: startsWith(matrix.os, 'windows')
         uses: samuelmeuli/action-electron-builder@v1
         with:
           github_token: ${{ secrets.github_token }}
           release: false
-          args: --${{ matrix.arch }}
+          # Use the release config so azureSignOptions is applied (dev/local
+          # builds use electron-builder.yml and stay unsigned).
+          args: --${{ matrix.arch }} --config electron-builder.release.yml
         env:
-          # Consumed by electron-builder's azureSignOptions (electron-builder.yml).
-          # Signing inside the build also covers the inner NethLink.exe and the
+          # Consumed by electron-builder.release.yml's azureSignOptions. Signing
+          # inside the build also covers the inner NethLink.exe and the
           # uninstaller, not just the installer.
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -72,7 +72,8 @@ jobs:
           path: notarization-error.log
           if-no-files-found: ignore
 
-      # --- Windows: build without release, sign, then upload ---
+      # --- Windows: build (electron-builder signs every binary via Azure
+      # Trusted Signing during packaging), then upload ---
       - name: Build Electron app (Windows)
         if: startsWith(matrix.os, 'windows')
         uses: samuelmeuli/action-electron-builder@v1
@@ -80,22 +81,16 @@ jobs:
           github_token: ${{ secrets.github_token }}
           release: false
           args: --${{ matrix.arch }}
-
-      - name: Sign Windows installer with Azure Trusted Signing
-        if: startsWith(matrix.os, 'windows')
-        uses: azure/trusted-signing-action@v1.2.0
-        with:
-          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
-          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
-          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT }}
-          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE }}
-          files-folder: dist/
-          files-folder-filter: exe
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
+        env:
+          # Consumed by electron-builder's azureSignOptions (electron-builder.yml).
+          # Signing inside the build also covers the inner NethLink.exe and the
+          # uninstaller, not just the installer.
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_SIGNING_ENDPOINT: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          AZURE_SIGNING_ACCOUNT: ${{ secrets.AZURE_SIGNING_ACCOUNT }}
+          AZURE_CERT_PROFILE: ${{ secrets.AZURE_CERT_PROFILE }}
 
       - name: Upload signed Windows installer to release
         if: startsWith(matrix.os, 'windows') && startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -38,6 +38,16 @@ jobs:
           echo '${{ secrets.api_key }}' > ~/private_keys/AuthKey_${{ secrets.api_key_id }}.p8
           xcrun --find notarytool
 
+      - name: Install Linux build dependencies (libuiohook/X11)
+        if: matrix.os == 'ubuntu-latest'
+        # uiohook-napi is rebuilt from source against Electron's ABI and needs
+        # the X11 dev headers (X11/keysym.h) to compile libuiohook.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libx11-dev libxtst-dev libxt-dev \
+            libxinerama-dev libx11-xcb-dev libxkbcommon-dev \
+            libxkbcommon-x11-dev libxkbfile-dev
+
       - name: Build/release Electron app (macOS/Linux)
         if: "!startsWith(matrix.os, 'windows')"
         uses: samuelmeuli/action-electron-builder@v1

--- a/electron-builder.release.yml
+++ b/electron-builder.release.yml
@@ -1,0 +1,21 @@
+# Release-only config: inherits everything from electron-builder.yml and adds
+# Windows code signing via Azure Trusted Signing. Used only by the prod release
+# workflow (build-prod.yml) for the Windows build, so dev/PR and local builds
+# remain unsigned and credential-free.
+#
+# Signing during the build (rather than as a post-build step on the installer)
+# ensures the inner app binary (NethLink.exe) and the uninstaller are signed
+# too — not just the NSIS installer. An unsigned NethLink.exe is what Windows
+# Smart App Control blocks.
+extends: ./electron-builder.yml
+win:
+  azureSignOptions:
+    # Must match the Common Name (CN) of the Trusted Signing certificate EXACTLY
+    # (also used by electron-updater to verify update signatures).
+    # Verify with: (Get-AuthenticodeSignature <signed-setup.exe>).SignerCertificate.Subject
+    publisherName: 'Nethesis Srl'
+    endpoint: ${env.AZURE_SIGNING_ENDPOINT}
+    codeSigningAccountName: ${env.AZURE_SIGNING_ACCOUNT}
+    certificateProfileName: ${env.AZURE_CERT_PROFILE}
+    timestampRfc3161: http://timestamp.acs.microsoft.com
+    timestampDigest: SHA256

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -29,20 +29,9 @@ win:
   icon: icons/icon.ico
   target:
     - nsis
-  # Sign with Azure Trusted Signing *during* the build, so electron-builder
-  # signs the inner app binary (NethLink.exe), the uninstaller and the NSIS
-  # installer. Signing the installer afterwards is not enough: the app exe is
-  # already sealed (unsigned) inside it, which is what Smart App Control blocks.
-  azureSignOptions:
-    # IMPORTANT: must match the Common Name (CN) of the Trusted Signing
-    # certificate EXACTLY (also used by electron-updater's signature check).
-    # Verify with: (Get-AuthenticodeSignature <signed-setup.exe>).SignerCertificate.Subject
-    publisherName: 'Nethesis Srl'
-    endpoint: ${env.AZURE_SIGNING_ENDPOINT}
-    codeSigningAccountName: ${env.AZURE_SIGNING_ACCOUNT}
-    certificateProfileName: ${env.AZURE_CERT_PROFILE}
-    timestampRfc3161: http://timestamp.acs.microsoft.com
-    timestampDigest: SHA256
+  # NOTE: Windows code signing (Azure Trusted Signing) is intentionally NOT
+  # configured here so that dev/PR and local builds don't need credentials and
+  # stay fast. Signing is added only for releases via electron-builder.release.yml.
 nsis:
   oneClick: false
   perMachine: true

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,6 @@
 appId: 'com.nethesis.nethlink.app'
 productName: 'NethLink'
-copyright: 'Copyright © 2025 NethesisSRL'
+copyright: 'Copyright © 2026 NethesisSRL'
 afterSign: electron-builder-notarize
 electronLanguages:
   - en
@@ -29,6 +29,20 @@ win:
   icon: icons/icon.ico
   target:
     - nsis
+  # Sign with Azure Trusted Signing *during* the build, so electron-builder
+  # signs the inner app binary (NethLink.exe), the uninstaller and the NSIS
+  # installer. Signing the installer afterwards is not enough: the app exe is
+  # already sealed (unsigned) inside it, which is what Smart App Control blocks.
+  azureSignOptions:
+    # IMPORTANT: must match the Common Name (CN) of the Trusted Signing
+    # certificate EXACTLY (also used by electron-updater's signature check).
+    # Verify with: (Get-AuthenticodeSignature <signed-setup.exe>).SignerCertificate.Subject
+    publisherName: 'Nethesis Srl'
+    endpoint: ${env.AZURE_SIGNING_ENDPOINT}
+    codeSigningAccountName: ${env.AZURE_SIGNING_ACCOUNT}
+    certificateProfileName: ${env.AZURE_CERT_PROFILE}
+    timestampRfc3161: http://timestamp.acs.microsoft.com
+    timestampDigest: SHA256
 nsis:
   oneClick: false
   perMachine: true


### PR DESCRIPTION
## Problem

On Windows 11, Smart App Control started blocking the app with:

It had worked for ~a month on release 1.4.5, then broke suddenly on a single machine. That is the expected behavior of Smart App Control: it is reputation-based and evaluated per-device in Microsoft's cloud. The device's SAC simply flipped from *evaluation* to *enforcing* mode, and at that point it started blocking unsigned binaries.

Verified on the affected machine:

```powershell
Get-AuthenticodeSignature "C:\Program Files\NethLink\NethLink.exe"
# Status: NotSigned   SignatureType: None
```

## Root cause

The release workflow signed Windows binaries as a **post-build step** with `azure/trusted-signing-action`, targeting `dist/*.exe`. By the time that step ran, `dist/` contained only the **installer** (`NethLink-<ver>-setup.exe`). The inner application binary (`NethLink.exe`) and the uninstaller were already packed **unsigned** inside the NSIS installer.

Result: the installer was signed (SmartScreen happy at download/install), but the extracted `C:\Program Files\NethLink\NethLink.exe` was never signed — exactly the file SAC blocks.

## Fix

Move signing **into** electron-builder via `win.azureSignOptions` (natively supported in electron-builder 26). electron-builder signs each binary at the right point in the pipeline:

- `NethLink.exe` (app) — `signApp`
- `Uninstall NethLink.exe` — `signIf(uninstallerPath)`
- `NethLink-<ver>-setup.exe` (installer) — `signIf(installerPath)`

All three route through the same Azure Trusted Signing manager, so **the installer stays signed** and the inner binaries are now signed too. The external `azure/trusted-signing-action` step becomes redundant and is removed; the existing `AZURE_*` secrets are passed to the build instead.

`publisherName` is set to the exact certificate Common Name (`Nethesis Srl`, read from the signed 1.4.5 installer). This matters beyond SAC: electron-updater uses `publisherName` to verify the signature of auto-updates, so it must match the cert CN.

### Signing coverage

| File | Before (external action) | After (electron-builder) |
|------|:---:|:---:|
| `NethLink-<ver>-setup.exe` (installer) | ✅ | ✅ |
| `NethLink.exe` (app) | ❌ | ✅ |
| `Uninstall NethLink.exe` | ❌ | ✅ |

